### PR TITLE
r'Sponsoring Registrar Organization:\s?(.+)' is registrar not registrant

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -316,7 +316,7 @@ uz = {
 id = {
     'extend': 'com',
 
-    'registrant':				r'Sponsoring Registrar Organization:\s?(.+)',
+    'registrar':				r'Sponsoring Registrar Organization:\s?(.+)',
 
     'creation_date':			r'Created On:\s?(.+)',
     'expiration_date':			r'Expiration Date:\s?(.+)',


### PR DESCRIPTION
the data on 'Sponsoring Registrar Organization' line is the registrar entity, not registrant. Therefore should be inserted into registrar object dictionary.